### PR TITLE
Fix required fields validation error

### DIFF
--- a/community-connect/COMPANY_DASHBOARD_VALIDATION_FIX.md
+++ b/community-connect/COMPANY_DASHBOARD_VALIDATION_FIX.md
@@ -1,0 +1,126 @@
+# Company Dashboard Validation Fix
+
+## Issue Description
+Companies were unable to create opportunities despite filling out all visible required fields. The form would show "Missing required fields" error when submitting the opportunity creation form. Additionally, the "Expected Duration" field needed to be made required.
+
+## Root Cause Analysis
+The issue was caused by a **field mismatch between the frontend form and the API validation**:
+
+1. **Missing Field in API**: The API was checking for a `time` field that didn't exist in the form
+2. **Form Field Mismatch**: The form used `arrivalTime` and `departureTime`, but the API expected `time`
+3. **Expected Duration Not Required**: The `departureTime` (Expected End Time) was optional when it should be required
+
+## Fixes Applied
+
+### 1. Fixed API Validation Logic
+**File:** `pages/api/companies/opportunities.js`
+
+**Before (POST method validation):**
+```javascript
+if (!title || !description || !category || !date || !time || !arrivalTime || !totalSpots || !location || !companyId) {
+  return res.status(400).json({ error: 'Missing required fields' });
+}
+```
+
+**After:**
+```javascript
+if (!title || !description || !category || !date || !arrivalTime || !departureTime || !totalSpots || !location || !companyId) {
+  return res.status(400).json({ error: 'Missing required fields' });
+}
+```
+
+**Changes:**
+- ❌ Removed `time` field (doesn't exist in form)
+- ✅ Added `departureTime` as required field
+
+**Before (PUT method validation):**
+```javascript
+if (!id || !title || !description || !category || !date || !time || !arrivalTime || !totalSpots || !location || !companyId) {
+  return res.status(400).json({ error: 'Missing required fields' });
+}
+```
+
+**After:**
+```javascript
+if (!id || !title || !description || !category || !date || !arrivalTime || !departureTime || !totalSpots || !location || !companyId) {
+  return res.status(400).json({ error: 'Missing required fields' });
+}
+```
+
+### 2. Removed Unused 'time' Field from Data Objects
+**File:** `pages/api/companies/opportunities.js`
+
+**Removed from opportunity creation:**
+```javascript
+// Removed this line:
+time,
+```
+
+**Removed from opportunity update:**
+```javascript
+// Removed this line:  
+time,
+```
+
+### 3. Made Expected End Time Required in Frontend
+**File:** `pages/company-dashboard.js`
+
+**Before:**
+```jsx
+<label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="departureTime">
+  Expected End Time
+</label>
+<input
+  // ... other props
+  name="departureTime"
+  value={opportunityFormData.departureTime}
+  onChange={handleOpportunityFormChange}
+/>
+<p className="text-xs text-gray-500 mt-1">When will the volunteers be done? (Optional but helpful)</p>
+```
+
+**After:**
+```jsx
+<label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="departureTime">
+  Expected End Time <span className="text-red-500">*</span>
+</label>
+<input
+  // ... other props
+  name="departureTime"
+  value={opportunityFormData.departureTime}
+  onChange={handleOpportunityFormChange}
+  required
+/>
+<p className="text-xs text-gray-500 mt-1">When will the volunteers be done? This helps volunteers plan their day.</p>
+```
+
+**Changes:**
+- ✅ Added red asterisk (*) to indicate required field
+- ✅ Added `required` attribute to input
+- ✅ Updated help text to be more informative
+
+## Current Required Fields
+After the fix, the following fields are required for opportunity creation:
+
+1. **Title** ✓
+2. **Description** ✓  
+3. **Category** ✓
+4. **Date** ✓
+5. **Arrival Time** ✓
+6. **Expected End Time** ✓ **(NOW REQUIRED)**
+7. **Total Volunteer Spots** ✓
+8. **Location Address** ✓
+9. **Company ID** ✓ (automatically provided)
+
+## Verification
+- ✅ Frontend form validation now matches API expectations
+- ✅ All required fields properly marked with red asterisk (*)
+- ✅ Expected Duration is now a required field as requested
+- ✅ Companies can successfully create opportunities when all fields are filled
+- ✅ Appropriate error messages shown when required fields are missing
+
+## Impact
+- Companies can now successfully post opportunities without validation errors
+- Better user experience with clear required field indicators
+- Expected Duration is now mandatory, providing better information to volunteers
+- Form validation is consistent between frontend and backend

--- a/community-connect/pages/api/companies/opportunities.js
+++ b/community-connect/pages/api/companies/opportunities.js
@@ -76,7 +76,7 @@ export default async function handler(req, res) {
       } = req.body;
 
       // Validate required fields
-      if (!title || !description || !category || !date || !time || !arrivalTime || !totalSpots || !location || !companyId) {
+      if (!title || !description || !category || !date || !arrivalTime || !departureTime || !totalSpots || !location || !companyId) {
         return res.status(400).json({ error: 'Missing required fields' });
       }
 
@@ -103,7 +103,6 @@ export default async function handler(req, res) {
         spotsTotal: parseInt(totalSpots),
         spotsFilled: 0,
         location,
-        time,
         arrivalTime,
         departureTime,
         meetingPoint,
@@ -220,7 +219,7 @@ export default async function handler(req, res) {
         recurringDays
       } = req.body;
 
-      if (!id || !title || !description || !category || !date || !time || !arrivalTime || !totalSpots || !location || !companyId) {
+      if (!id || !title || !description || !category || !date || !arrivalTime || !departureTime || !totalSpots || !location || !companyId) {
         return res.status(400).json({ error: 'Missing required fields' });
       }
 
@@ -253,7 +252,6 @@ export default async function handler(req, res) {
         category,
         priority: priority || 'Medium',
         date,
-        time,
         arrivalTime,
         departureTime,
         spotsTotal: parseInt(totalSpots),

--- a/community-connect/pages/company-dashboard.js
+++ b/community-connect/pages/company-dashboard.js
@@ -480,7 +480,7 @@ export default function CompanyDashboard() {
 
             <div className="mb-4">
               <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="departureTime">
-                Expected End Time
+                Expected End Time <span className="text-red-500">*</span>
               </label>
               <input
                 className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
@@ -489,8 +489,9 @@ export default function CompanyDashboard() {
                 name="departureTime"
                 value={opportunityFormData.departureTime}
                 onChange={handleOpportunityFormChange}
+                required
               />
-              <p className="text-xs text-gray-500 mt-1">When will the volunteers be done? (Optional but helpful)</p>
+              <p className="text-xs text-gray-500 mt-1">When will the volunteers be done? This helps volunteers plan their day.</p>
             </div>
 
             <div className="mb-4">


### PR DESCRIPTION
Fixes opportunity creation validation errors and makes 'Expected End Time' a required field.

The API was incorrectly validating for a non-existent `time` field while the frontend used `arrivalTime` and `departureTime`. This PR aligns the backend validation with the frontend fields and enforces 'Expected End Time' as required, as per user request.