### PR TITLE
Fix password reset 'user not found' error in MyCommitments

### DIFF
--- a/community-connect/components/Commitments/MyCommitments.jsx
+++ b/community-connect/components/Commitments/MyCommitments.jsx
@@ -652,7 +652,7 @@ const DormManagement = ({ currentUser, onDormUpdate }) => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          userId: currentUser._id,
+          userId: currentUser._id.toString ? currentUser._id.toString() : currentUser._id,
           currentPassword: passwordData.currentPassword,
           newPassword: passwordData.newPassword
         }),

--- a/community-connect/pages/api/users/update-password.js
+++ b/community-connect/pages/api/users/update-password.js
@@ -31,7 +31,7 @@ export default async function handler(req, res) {
 
     // Connect to MongoDB
     const client = await clientPromise;
-    const db = client.db('main_street');
+    const db = client.db('mainStreetOpportunities');
     const usersCollection = db.collection('users');
 
     // Find user


### PR DESCRIPTION
- Fixed userId format issue by ensuring proper string conversion
- Corrected database name from 'main_street' to 'mainStreetOpportunities'
- Both issues were causing the password update API to fail with 'user not found'