### PR TITLE
Load hero section content from MongoDB

### DIFF
--- a/community-connect/components/Hero/HeroSection.jsx
+++ b/community-connect/components/Hero/HeroSection.jsx
@@ -5,13 +5,12 @@ import Button from '../ui/Button';
 import Icon from '../ui/Icon';
 import useContent from '../../lib/useContent';
 
-const HeroSection = forwardRef(({ content, ...props }, ref) => {
+const HeroSection = forwardRef((_, ref) => {
   const [isVisible, setIsVisible] = useState(false);
-  const { content: dynamicContent } = useContent();
-  const mergedContent = { ...dynamicContent, ...content };
+  const { content } = useContent();
 
-  const getContent = (key, defaultValue = '') => {
-    return mergedContent[key] || defaultValue;
+  const getContent = (key) => {
+    return content[key] || '';
   };
   
   useEffect(() => {
@@ -49,36 +48,36 @@ const HeroSection = forwardRef(({ content, ...props }, ref) => {
 
           
           <h1 className="hero-title relative font-montserrat text-clamp-36-64 font-extrabold mb-8 md:mb-10 tracking-[-0.025em] text-primary leading-tight inline-block">
-{getContent('hero.title', 'Make the Connection')}
+{getContent('hero.title')}
             <span className="absolute -bottom-2 left-1/2 transform -translate-x-1/2 w-24 h-1 bg-gradient-to-r from-primary to-accent1 rounded-full"></span>
           </h1>
           
           <p className="font-source-serif text-clamp-18-24 font-normal text-text-secondary mb-10 max-w-2xl mx-auto leading-relaxed">
-{getContent('hero.subtitle', 'Connect with meaningful opportunities that create lasting impact in upland.')}
+{getContent('hero.subtitle')}
           </p>
           
           <div className="flex flex-wrap justify-center gap-4 mb-16">
-            <Button 
-              variant="primary" 
+            <Button
+              variant="primary"
               className="group text-base px-8 py-4 shadow-lg hover:shadow-xl"
               onClick={scrollToOpportunities}
             >
-{getContent('hero.cta.primary', 'Find Opportunities')}
+{getContent('hero.cta.primary')}
               <Icon 
                 path="M13 7l5 5m0 0l-5 5m5-5H6" 
                 className="ml-2 w-5 h-5 inline-block transition-transform group-hover:translate-x-1"
               />
             </Button>
             <Link href="/about">
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 className="text-base px-8 py-4"
               >
-{getContent('hero.cta.secondary', 'Learn More')}
+{getContent('hero.cta.secondary')}
               </Button>
             </Link>
           </div>
-          <HeroStats content={mergedContent} />
+          <HeroStats />
         </div>
       </div>
     </section>

--- a/community-connect/components/Hero/HeroSection.jsx
+++ b/community-connect/components/Hero/HeroSection.jsx
@@ -7,9 +7,11 @@ import useContent from '../../lib/useContent';
 
 const HeroSection = forwardRef(({ content, ...props }, ref) => {
   const [isVisible, setIsVisible] = useState(false);
-  
+  const { content: dynamicContent } = useContent();
+  const mergedContent = { ...dynamicContent, ...content };
+
   const getContent = (key, defaultValue = '') => {
-    return content?.[key] || defaultValue;
+    return mergedContent[key] || defaultValue;
   };
   
   useEffect(() => {
@@ -76,7 +78,7 @@ const HeroSection = forwardRef(({ content, ...props }, ref) => {
               </Button>
             </Link>
           </div>
-          <HeroStats content={content} />
+          <HeroStats content={mergedContent} />
         </div>
       </div>
     </section>

--- a/community-connect/components/Hero/HeroStats.jsx
+++ b/community-connect/components/Hero/HeroStats.jsx
@@ -3,7 +3,7 @@ import StatItem from './StatItem';
 import { fetchMetrics } from '../../lib/metricsUtils';
 import useContent from '../../lib/useContent';
 
-const HeroStats = ({ content }) => {
+const HeroStats = () => {
   const statsRef = useRef(null);
   const [metrics, setMetrics] = useState({
     volunteersConnected: 0,
@@ -11,10 +11,10 @@ const HeroStats = ({ content }) => {
     hoursServed: 0
   });
   const [loading, setLoading] = useState(true);
-  const { content: dynamicContent } = useContent();
+  const { content } = useContent();
 
-  const getContent = (key, defaultValue = '') => {
-    return content?.[key] || dynamicContent[key] || defaultValue;
+  const getContent = (key) => {
+    return content[key] || '';
   };
   
   useEffect(() => {
@@ -86,22 +86,22 @@ const HeroStats = ({ content }) => {
       <div className="absolute top-0 left-1/2 transform -translate-x-1/2 w-24 h-px bg-border-light"></div>
       
       <div className="flex flex-col gap-6 md:grid md:grid-cols-3 md:gap-8 mt-8 max-w-4xl mx-auto relative z-10">
-        <StatItem 
-          className="stat-item" 
-          target={metrics.volunteersConnected} 
-          label={getContent('stats.volunteers.label', 'Volunteers Connected')} 
-          icon="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 0 1 5 15.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 0 1 9 19.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" 
+        <StatItem
+          className="stat-item"
+          target={metrics.volunteersConnected}
+          label={getContent('stats.volunteers.label')}
+          icon="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 0 1 5 15.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 0 1 9 19.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
         />
-        <StatItem 
-          className="stat-item" 
-          target={metrics.hoursServed} 
-          label={getContent('stats.impact.label', 'Hours Served')} 
-          icon="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" 
+        <StatItem
+          className="stat-item"
+          target={metrics.hoursServed}
+          label={getContent('stats.impact.label')}
+          icon="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
         />
         <StatItem 
           className="stat-item" 
           target={metrics.organizationsInvolved} 
-          label={getContent('stats.organizations.label', 'Organizations Involved')} 
+          label={getContent('stats.organizations.label')} 
           icon="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" 
         />
       </div>

--- a/community-connect/components/Hero/HeroStats.jsx
+++ b/community-connect/components/Hero/HeroStats.jsx
@@ -11,9 +11,10 @@ const HeroStats = ({ content }) => {
     hoursServed: 0
   });
   const [loading, setLoading] = useState(true);
-  
+  const { content: dynamicContent } = useContent();
+
   const getContent = (key, defaultValue = '') => {
-    return content?.[key] || defaultValue;
+    return content?.[key] || dynamicContent[key] || defaultValue;
   };
   
   useEffect(() => {

--- a/community-connect/pages/index.js
+++ b/community-connect/pages/index.js
@@ -381,7 +381,7 @@ export default function Home({ content }) {
     <>
       <Header openModal={openModal} content={content} />
       <main>
-        <HeroSection ref={heroContentRef} content={content} />
+        <HeroSection ref={heroContentRef} />
         <FloatingCardSection content={content} />
         <SearchSection
         filter={filter}


### PR DESCRIPTION
## Summary
- fetch content from MongoDB on the Hero page
- use merged dynamic content in Hero stats

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d85e283148320bbac60a523a63e40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined content loading in the Hero section and Hero stats by fetching content internally, improving consistency and reliability.
  * Removed redundant fallback text for labels and content, ensuring dynamic content is displayed accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->